### PR TITLE
wkdev_sdk: Remove xdg-open workaround

### DIFF
--- a/images/wkdev_sdk/Containerfile
+++ b/images/wkdev_sdk/Containerfile
@@ -61,9 +61,6 @@ ENV LC_ALL ${CONTAINER_LOCALE}
 ENV LANG ${CONTAINER_LOCALE}
 RUN dpkg-reconfigure locales
 
-# As we are in a container normal xdg-open doesn't work but we can use flatpak's portal instead.
-RUN ln -s /usr/libexec/flatpak-xdg-utils/xdg-open /usr/local/bin/xdg-open
-
 # Install all dependencies for WebKit/GStreamer/etc in one pass.
 WORKDIR /var/tmp/wkdev-packages
 COPY /required_system_packages/*.lst .

--- a/images/wkdev_sdk/required_system_packages/01-base.lst
+++ b/images/wkdev_sdk/required_system_packages/01-base.lst
@@ -11,4 +11,4 @@ libnvidia-egl-wayland1
 wireplumber
 
 # General utilities
-apt-file aptly atop at-spi2-core emacs flatpak-xdg-utils git htop iotop iputils-ping kmod less libportal-dev libportal-gtk4-dev libxcb-cursor-dev locate man-db nano openssh-client strace sudo unzip vim wget
+apt-file aptly atop at-spi2-core emacs git htop iotop iputils-ping kmod less libportal-dev libportal-gtk4-dev libxcb-cursor-dev locate man-db nano openssh-client strace sudo unzip vim wget


### PR DESCRIPTION
This doesn't work on file:// URIs which is important. Users will just need a browser in the container.